### PR TITLE
Updated Link for SPCA homepage, previous one was 404

### DIFF
--- a/src/templates/subjects/semester3.ts
+++ b/src/templates/subjects/semester3.ts
@@ -106,7 +106,7 @@ export default [
     name: 'Systems Programming and Computer Architecture',
     lecturer: 'Prof. Timothy Roscoe',
     mainLink:
-      'https://systems.ethz.ch/education/courses/2022-autumn/systems-programming-and-computer-architecture.html',
+      'https://systems.ethz.ch/education/courses/2022-autumn-semester/systems-programming-and-computer-architecture-.html',
     links: [
       {
         id: nanoid(5),


### PR DESCRIPTION
SPCA changed their link from previous years and added "-semester" and a dash at the very end